### PR TITLE
Fix error: using integer constants in boolean context [-Werror=int-in-bool-context]

### DIFF
--- a/src/per_curve/point.tmpl.hxx
+++ b/src/per_curve/point.tmpl.hxx
@@ -305,7 +305,7 @@ public:
     */
     inline explicit Point(const FixedBlock<SER_BYTES> &buffer, bool allow_identity=true)
         /*throw(CryptoException)*/ {
-        if (DECAF_SUCCESS != decode(buffer,allow_identity ? DECAF_TRUE : DECAF_FALSE)) {
+        if (DECAF_SUCCESS != decode(buffer,allow_identity ? (bool)DECAF_TRUE : (bool)DECAF_FALSE)) {
             throw CryptoException();
         }
     }


### PR DESCRIPTION
fixes #1 and https://github.com/stef/libsphinx/issues/2